### PR TITLE
Add opOpAssign overloads

### DIFF
--- a/source/roaring/c.d
+++ b/source/roaring/c.d
@@ -60,11 +60,27 @@ void roaring_bitmap_add_many(roaring_bitmap_t *r, size_t n_args, const uint32_t 
 roaring_bitmap_t *roaring_bitmap_and(const roaring_bitmap_t *x1, const roaring_bitmap_t *x2);
 
 /**
+ * Inplace version modifies x1, x1 == x2 is allowed
+ */
+@nogc @safe
+void roaring_bitmap_and_inplace(roaring_bitmap_t *x1,
+                                const roaring_bitmap_t *x2);
+
+/**
  * Computes the union between two bitmaps and returns new bitmap. The caller is
  * responsible for memory management.
  */
 @nogc @safe
 roaring_bitmap_t *roaring_bitmap_or(const roaring_bitmap_t *x1, const roaring_bitmap_t *x2);
+
+/**
+ * Inplace version of roaring_bitmap_or, modifies x1. TDOO: decide whether x1 ==
+ *x2 ok
+ *
+ */
+@nogc @safe
+void roaring_bitmap_or_inplace(roaring_bitmap_t *x1,
+                               const roaring_bitmap_t *x2);
 
 /**
  * Computes the symmetric difference (xor) between two bitmaps
@@ -73,6 +89,13 @@ roaring_bitmap_t *roaring_bitmap_or(const roaring_bitmap_t *x1, const roaring_bi
 @nogc @safe
 roaring_bitmap_t *roaring_bitmap_xor(const roaring_bitmap_t *x1, const roaring_bitmap_t *x2);
 
+/**
+ * Inplace version of roaring_bitmap_xor, modifies x1. x1 != x2.
+ *
+ */
+@nogc @safe
+void roaring_bitmap_xor_inplace(roaring_bitmap_t *x1,
+                                const roaring_bitmap_t *x2);
 
 @nogc @safe
 bool roaring_bitmap_contains(const roaring_bitmap_t *r, uint32_t val) pure;

--- a/source/roaring/roaring.d
+++ b/source/roaring/roaring.d
@@ -385,6 +385,32 @@ class Bitmap
         assert((r1 ^ r2) == bitmapOf(1, 2, 3, 5, 7, 8));
     }
 
+    @nogc
+    void opOpAssign(const string op)(const Bitmap b)
+    if (op == "&" || op == "|" || op == "^")
+    {
+        static if (op == "&") roaring_bitmap_and_inplace(this.bitmap, b.bitmap);
+        else static if (op == "|") roaring_bitmap_or_inplace(this.bitmap, b.bitmap);
+        else static if (op == "^") roaring_bitmap_xor_inplace(this.bitmap, b.bitmap);
+        else static assert(0, "Operator " ~ op ~ " not implemented.");
+    }
+
+    unittest
+    {
+        auto r1 = bitmapOf(5, 1, 2, 3, 5, 6);
+        const r2 = bitmapOf(6, 7, 8);
+        r1 |= r2;
+        assert(r1 == bitmapOf(1, 2, 3, 5, 6, 7, 8));
+
+        r1 = bitmapOf(5, 1, 2, 3, 5, 6);
+        r1 &= r2;
+        assert(r1 == bitmapOf(6));
+
+        r1 = bitmapOf(5, 1, 2, 3, 5, 6);
+        r1 ^= r2;
+        assert(r1 == bitmapOf(1, 2, 3, 5, 7, 8));
+    }
+
     @nogc @safe
     bool opBinaryRight(const string op)(const uint x) const
     if (op == "in")


### PR DESCRIPTION
Adds support for the `_inplace` variant of the `|`, `&`, and `^`
operations.